### PR TITLE
Follow redirects and 302 Found

### DIFF
--- a/src/get_html_sync.js
+++ b/src/get_html_sync.js
@@ -6,11 +6,16 @@ function getHtmlSync(url) {
   const xhr = new XMLHttpRequest();
   try {
     xhr.open('GET', url, false);
+    xhr.followRedirects = true;
     xhr.send();
   } catch (err) {
     throw new Error('XMLHttpRequest(' + url + ') failed. ' + err);
   }
 
+  if (xhr.readyState === 4 && (xhr.status === 301 || xhr.status === 302)) {
+    const redirectUrl = xhr.getResponseHeader('Location');
+    return getHtmlSync(redirectUrl);
+  }
   if (xhr.status != 200) {
     const statusText = xhr.statusText ? xhr.statusText : '';
     throw new Error(

--- a/src/get_html_sync.js
+++ b/src/get_html_sync.js
@@ -1,7 +1,11 @@
 const XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
 
-function getHtmlSync(url) {
+function getHtmlSync(url, redirectLimit = 5) {
   // TODO url check
+
+  if (redirectLimit <= 0) {
+    throw new Error('Too many redirects');
+  }
 
   const xhr = new XMLHttpRequest();
   try {
@@ -14,12 +18,12 @@ function getHtmlSync(url) {
 
   if (xhr.readyState === 4 && (xhr.status === 301 || xhr.status === 302)) {
     const redirectUrl = xhr.getResponseHeader('Location');
-    return getHtmlSync(redirectUrl);
+    return getHtmlSync(redirectUrl, redirectLimit - 1);
   }
   if (xhr.status != 200) {
     const statusText = xhr.statusText ? xhr.statusText : '';
     throw new Error(
-        'XMLHttpRequest(' + url + ') status:' + xhr.status + ' ' + statusText,
+      'XMLHttpRequest(' + url + ') status:' + xhr.status + ' ' + statusText,
     );
   }
   return xhr.responseText;


### PR DESCRIPTION
Hello there!

First, I want to say thank you for your plugin! I use it on my website and it is quite handy :)

So, I ran into a bug today, when I tried to get previews from Instagram.
The plugin throw me this error:
`Error: XMLHttpRequest(https://www.instagram.com/<redacted>/) status:302`

I did some digging and I think I found a fix, although it might not be very elegant. I think that because, as far as I interpret it, XMLHttpRequest should be able to do this for us, but the line `xhr.followRedirects = true;`, didn't do the trick for me. So I decided to check for the HTTP codes 301 and 302 and then follow their Location header recursively. My redirectLimit or recursion limit of 5 is kind of arbitrary, but I'm open to suggestions on what to set it to instead.

I hope my pull request find you well,
~ Padok
